### PR TITLE
feat: add fragment links to term definitions

### DIFF
--- a/glossary-utils.js
+++ b/glossary-utils.js
@@ -87,7 +87,7 @@ function md2rdfa(markdownString,conceptScheme,cssPath){
           typeof="skos:Concept"
           rel="skos:broader" resource="#${headerUrl}"
           property="skos:prefLabel"
-        ><dfn id="${url}">${head}</dfn></dt>
+        ><dfn id="${url}"><a href="#${url}">${head}</a></dfn></dt>
         <dd aria-labelledby="${url}">
           ${body}
         </dd>

--- a/glossary.css
+++ b/glossary.css
@@ -86,3 +86,26 @@ dd {
     --section-term-size: 120%;
   }
 }
+
+/* definition fragment links */
+
+dfn {
+  position: relative;
+}
+
+dfn a {
+  color: inherit;
+}
+
+dfn a::before {
+  content: '#';
+  position: absolute;
+  right: 100%;
+  opacity: 0;
+  padding-right: 0.25rem;
+  color: var(--link-color);
+}
+
+dfn a:hover::before {
+  opacity: 1;
+}


### PR DESCRIPTION
This should make the terms easier to reference.

It looks like this when hovered:

<img width="187" height="219" alt="image" src="https://github.com/user-attachments/assets/0d26105e-90a8-476a-942e-0406fe2a23f9" />

<img width="166" height="223" alt="image" src="https://github.com/user-attachments/assets/94387a8e-6883-46e9-851d-91ff33232766" />

And the generated HTML looks like:

```html
        <dt [...] ><dfn id="OWL"><a href="#OWL">OWL</a></dfn></dt>
```